### PR TITLE
fix: Add support for glc-lib master

### DIFF
--- a/opengl_view/OpenglView.cpp
+++ b/opengl_view/OpenglView.cpp
@@ -734,7 +734,7 @@ void OpenglView::mouseReleaseEvent(QMouseEvent * e)
 	{
 		if ((Qt::LeftButton == e->button()) && (m_ViewState == V_NORMAL))
 		{
-            glc::WidgetEventFlag eventFlag= m_3DWidgetManager.releaseEvent();
+            glc::WidgetEventFlag eventFlag= m_3DWidgetManager.releaseEvent(e);
 			if (eventFlag == glc::BlockedEvent) updateGL();
 
 		}
@@ -1037,7 +1037,7 @@ void OpenglView::select(int x, int y, bool multiSelection, QMouseEvent* pMouseEv
 
 	// 3DWidget manager test
     GLC_Point3d unprojeted(m_GlView.unproject(pMouseEvent->x(), pMouseEvent->y()));
-    glc::WidgetEventFlag eventFlag= m_3DWidgetManager.pressEvent(SelectionID, unprojeted);
+    glc::WidgetEventFlag eventFlag= m_3DWidgetManager.pressEvent(SelectionID, unprojeted, pMouseEvent);
 
 	m_SelectionMode= false;
 	setAutoBufferSwap(true);


### PR DESCRIPTION
It's been a bit since I researched it, but I believe this addresses changes in the library from [this commit](https://github.com/laumaya/GLC_lib/commit/26c17fdfc047394411287bde87eec743b6e82388)?

With this (and some patches to the build system and some [system libs](https://github.com/laumaya/GLC_lib/pull/43)), I am able to build the `next` branch of GLC_Player with the `master` branch of GLC_lib, and it seems to be working for the most part. I can open and look at some simple objects.
I haven't used or managed to build any other versions of this project, so I cannot tell if it works better or worse than them.

I am honestly not expecting this to be merged, but maybe this can be useful as public documentation for others trying to build this, because it looks like there's interest.

If you're using NixOS, a fully working derivation is [here](https://github.com/ShaddyDC/extra-nixpkgs/blob/62f452b39b92fbdf7b84f8cbc243c8ba6571ec42/pkgs/glc-player/default.nix) or below.
It will also have the exact commits that I've built from and the changes I had to take to build successfully.

<details><summary>Nix derivation</summary>
<p>

```nix
{
  mkDerivation,
  pkgs,
  fetchFromGitHub,
  ...
}:
with pkgs; let
  glc-lib = mkDerivation rec {
    pname = "GLC_lib";
    version = "3.0.1-2023-01-02";
    src = fetchFromGitHub {
      owner = "laumaya";
      repo = pname;
      rev = "382230b26374c5737cebd41fa7a08849acd85b46";
      hash = "sha256-qfqsq3Kxe2zMc+VYbWuHlXaHfYCNkxXRQNF4sGwHrjI=";
    };
    postPatch = ''
      # Fix install directories
      substituteInPlace install.pri \
        --replace "/usr/local" "$out" \
        --replace "/usr" "$out"

      # Don't build examples
      substituteInPlace glc_lib.pro \
        --replace "src/plugins" "src/plugins #" \
        --replace "src/examples" ""

      # Fix system quazip linking and building
      sed -i -e '1iINCLUDEPATH += ${libsForQt5.quazip.dev}/include/QuaZip-Qt5-1.4' src/lib/lib.pro
      substituteInPlace src/lib/lib.pro \
        --replace "-lquazip5" "-L${libsForQt5.quazip}/lib -lquazip1-qt5"
      substituteInPlace src/lib/shading/glc_texture.cpp \
        --replace '#include "quazip5' '#include "quazip'
    '';

    patches = [
      # Use system quazip
      (pkgs.fetchpatch {
        url = "https://github.com/laumaya/GLC_lib/pull/43.patch";
        hash = "sha256-NXw+r7UJkepZpnDmyCF60dngtraIsVXccaQcq/lwvFU=";
      })
    ];

    buildPhase = ''
      runHook preBuild

      ${qt5.qtbase.dev}/bin/qmake -recursive
      make -j$NIX_BUILD_CORES

      runHook postBuild
    '';

    buildInputs = [
      libGL
      qt5.qtbase
      qt5.wrapQtAppsHook
      libsForQt5.quazip
      zlib
    ];
  };
in
  mkDerivation {
    pname = "glc-player";
    version = "2.3.0-next-2019-12-02";

    src = fetchFromGitHub {
      owner = "laumaya";
      repo = "GLC_Player";
      rev = "f09f4dfb8416dc90cbe54962926d162169d50f6c";
      hash = "sha256-6ZRc3KDnxTsZuPUEsj8rZsw004dc4my7lJ0Cp37Q7uU=";
    };

    nativeBuildInputs = with pkgs; [
      qt5.qtbase
      qt5.wrapQtAppsHook
    ];

    patches = [
      ./player.patch
    ];

    postPatch = ''
      substituteInPlace glc_player.pro \
        --replace "/usr/local/include/GLC_lib-3.0" "${glc-lib}/include/GLC_lib-3.0" \
        --replace "/usr/local/lib"  "${glc-lib}/lib" \
        --replace "-lGLC_lib.3"  "-lGLC_lib"
    '';

    buildPhase = ''
      runHook preBuild

      ${qt5.qtbase.dev}/bin/qmake -recursive
      make -j$NIX_BUILD_CORES

      runHook postBuild
    '';

    postInstall = ''
      install -D -m755 glc_player $out/bin/glc_player
    '';
  }
```

</p>
</details> 